### PR TITLE
Fixed .gitignore file with old sdcc path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,4 @@ printer.txt
 
 *.binamsdos
 *.binamsdos.log
-cpctelera/tools/sdcc-3.4.3/share
+cpctelera/tools/sdcc-3.5.0/share


### PR DESCRIPTION
After `git clone` you get a clean repo, but after running `setup.sh`, if you look at the repo using [SourceTree](https://www.sourcetreeapp.com) you can see a bunch of files as not added to the repo.

All these files belong to sdcc. Just changing the old line for sdcc inside .gitignore fixes this issue.

But the strange thing is that `git status` does not show these files, but SourceTree does 😕