### PR TITLE
Keyboard Technicals table minor fix

### DIFF
--- a/cpctelera/docs/files/keyboard/keyboard-txt.html
+++ b/cpctelera/docs/files/keyboard/keyboard-txt.html
@@ -27,8 +27,8 @@ Table 1. Programmable Peripheral Interface (PPI) Ports</pre></blockquote><p>Keyb
 |=====|=============|============|=======|=====|=====|======|==============|=====|==========|===========|
 |  7  | f.          | f0         | Ctrl  | &gt; , | &lt; . | Space| V            | X   | Z        | Del       |
 |  6  | Enter       | f2         | ` \   | ? / | M   | N    | B            | C   | Caps Lock| Unused    |
-|  5  | f3          | f1         | Shift | * : | K   | J    | F Joy1_Fire1 | D   | A        | Joy0_Fire1|
-|  4  | f6          | f5         | f4    | + ; | L   | H    | G Joy1_Fire2 | S   | Tab      | Joy0_Fire2|
+|  5  | f3          | f1         | Shift | * : | K   | J    | F Joy1_Fire2 | D   | A        | Joy0_Fire2|
+|  4  | f6          | f5         | f4    | + ; | L   | H    | G Joy1_Fire1 | S   | Tab      | Joy0_Fire1|
 |  3  | f9          | f8         | } ]   | P   | I   | Y    | T Joy1_Right | W   | Q        | Joy0_Right|
 |  2  | Cursor Down | f7         | Return| | @ | O   | U    | R Joy1_Left  | E   | Esc      | Joy0_Left |
 |  1  | Cursor Right| Copy       | { [   | = - | ) 9 | ' 7  | % 5 Joy1_Down| # 3 | &quot; 2      | Joy0_Down |


### PR DESCRIPTION
Fixed Joy0_Fire1 and Joy0_Fire2 being swapped in the table (same with Joy1)