### PR TITLE
fixed issue with bin generation in IMG2SP_CONVERT_BIN

### DIFF
--- a/cpctelera/cfg/modules/img2sp.mk
+++ b/cpctelera/cfg/modules/img2sp.mk
@@ -276,7 +276,6 @@ define IMG2SP_CONVERT_BIN
 
 # Variables that need to be updated to ensure they are erased on clean
 IMGBINFILES := $(I2S_B2) $(IMGBINFILES)
-IMGASMFILES := $(I2S_S2) $(IMGASMFILES)
 OBJS2CLEAN  := $(I2S_CSB) $(OBJS2CLEAN)
 endef
 

--- a/cpctelera/cfg/modules/img2sp.mk
+++ b/cpctelera/cfg/modules/img2sp.mk
@@ -244,7 +244,7 @@ endef
 # $(5): C-identifier for the array containing generated palette (if required)
 # $(6): C-identifier for the array containing generated tileset (ignored: no tileset produced on binary output)
 #
-# Updates IMGCFILES, IMGASMFILES and OBJS2CLEAN adding new C files that result from the pack generation.
+# Updates IMGCFILES and OBJS2CLEAN adding new C files that result from the pack generation.
 #
 define IMG2SP_CONVERT_BIN
 	# Set up C and H files and paths


### PR DESCRIPTION
When converting an image to bin, the '.h.s' file was included into compilation, which generated unneeded lst, rst, rel and sym files that where not deleted with 'make clean' or 'make cleanall'