### PR TITLE
Fix compilation under MacOS Monterrey

### DIFF
--- a/cpctelera/tools/2cdt/src/2cdt.c
+++ b/cpctelera/tools/2cdt/src/2cdt.c
@@ -20,6 +20,7 @@
 /* The following program is designed to create a .tzx/.cdt from a tape-file stored
 on the PC */
 
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/cpctelera/tools/2cdt/src/tzxfile.h
+++ b/cpctelera/tools/2cdt/src/tzxfile.h
@@ -75,5 +75,6 @@ int	TZX_GetBlockHeaderSize(unsigned char ID);
 BOOL TZX_BlockHasData(unsigned char ID);
 TZX_BLOCK *TZX_CreateBlock(unsigned char ID);
 void	TZX_SetupPauseBlock(TZX_BLOCK *pBlock,unsigned long PauseInMilliseconds);
+void   TZX_AppendFile(TZX_FILE *pTZXFile, unsigned char *pFilename);
 #endif
 


### PR DESCRIPTION
Under MacOS Monterrey/Xcode 14.0.1, the current state of `master` fails to build. With those simple tweaks, it builds again.

Hope to see the professor at any of the retro events again! :)