### PR TITLE
New optimized version of cpct_px2byteM1.s

### DIFF
--- a/cpctelera/src/sprites/cpct_px2byteM1.s
+++ b/cpctelera/src/sprites/cpct_px2byteM1.s
@@ -49,9 +49,6 @@
 ;; Parameter Restrictions:
 ;;    * *px0*, *px1*, *px2* and *px3* must be firmware colour values in the range 
 ;; [0-3]. If any of them is greater than 3, unexpected colours may appear on screen.
-;; *px?* are used as indexes in a colour conversion table, and values greater
-;; than 3 would point outside the table, getting random memory values, which will
-;; lead to random colours on screen.
 ;;
 ;; Details:
 ;;    Converts 4 firmware colour values for 4 consecutive pixels into a byte value
@@ -59,77 +56,76 @@
 ;; is the way pixel colour values are encoded in video memory. Concretely, in 
 ;; Mode 1, each byte contains 4 consecutive pixels formatted as follows:
 ;; (start code)
-;;  ___________________________________________________________________________________
-;;                        <----------- 1 byte ----------->
-;;  Screen         => [...[pixelA][pixelB][pixelC][pixelD]...] (4 pixels, consecutive)
-;;  ===================================================================================
-;;  Video Memory   => [...[  A   B  C  D   A  B  C   D   ]...] (1  byte, 8 bits)
-;;  Pixel A   (10) => [...[  0   ·  ·  ·   1  ·  ·   ·   ]...] (2  bits)
-;;  Pixel B   (32) => [...[  ·   2  ·  ·   ·  3  ·   ·   ]...] (2  bits)
-;;  Pixel C   (54) => [...[  ·   ·  4  ·   ·  ·  5   ·   ]...] (2  bits)
-;;  Pixel D   (76) => [...[  ·   ·  ·  6   ·  ·  ·   7   ]...] (2  bits)
-;;  -----------------------------------------------------------------------------------
+;;  _____________________________________________________________________________
+;;  Screen
+;;  Layout       => [<------------ 1 byte ------------>]  (in byte boundary)
+;;  pixel format => (pixel A)(pixel B)(pixel C)(pixel D)  (4 pixels, consecutive)
+;;  =============================================================================
+;;  Video memory
+;;  Byte layout       => [ 7654 3210 ]  (1 byte, 8 bits order)
+;;  M1 pixels encoded => [ ABCD ABCD ]  (4 pixels bits order)
+;;  pixel A    [ 10 ] => [ 0... 1... ]  (2 low bits of pixel colour value)
+;;  pixel B    [ 10 ] => [ .0.. .1.. ]  (2 low bits of pixel colour value)
+;;  pixel C    [ 10 ] => [ ..0. ..1. ]  (2 low bits of pixel colour value)
+;;  pixel D    [ 10 ] => [ ...0 ...1 ]  (2 low bits of pixel colour value)
+;;  -----------------------------------------------------------------------------
 ;;              Scheme 1. Screen pixel format and video memory
 ;; (end)
 ;;   
-;;    This function uses a 4-byte conversion table to get screen formatted values
-;; for each one of the two pixels given. These formatted values are then OR'ed to 
-;; get the final byte that you may use to draw on screen.
-;;
 ;; Destroyed Register values:
-;;    AF, BC, DE, HL
+;;    AF, BC, HL
 ;;
 ;; Required memory:
-;;    29 bytes (25 bytes code, 4 bytes colour conversion table)
-;;
-;;   Note - Colour conversion table is shared with <cpct_drawCharM1>. If you use both
-;; functions, only one copy of the colour table is loaded into memory.
+;;    33 bytes
 ;;
 ;; Time Measures:
 ;; (start code)
 ;; Case  | microSecs (us) | CPU Cycles
 ;; ------------------------------------
-;; Any   |      96        |   384
+;; Any   |      57        |   201
 ;; ------------------------------------
 ;; (end code)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-;; Include required macro files
-.include "macros/cpct_maths.h.s"
 
 cpct_px2byteM1_asm::
 _cpct_px2byteM1::
    ;; Point HL to the start of the first parameter in the stack
    ld   hl, #2           ;; [3] HL Points to SP+2 (first 2 bytes are return address)
-   ld    c, h            ;; [1] C = 0 (Byte in video memory pixel format)
+   ld    b, l            ;; [1] B = L (2) counter to loop twice
    add  hl, sp           ;; [3]    , to use it for getting parameters from stack
+   ld    c, #0x10        ;; [2] C = 0x10 Mask to set into high nibble
 
-   ;;
-   ;; Transform next pixel into Screen Pixel Format
-   ;;
-   ld    b, #4           ;; [2] We have 4 pixels to mix into 1 byte, so set loop counter to 4
+   ;; Process the first pixel
+   ld    a, (hl)         ;; [2] A = Firmware colour first pixel
+   rra                   ;; [1] Shift to the right, the bit 0 (low bit of pixel) is stored into fC
+   jr   nc, loop1        ;; [2/3] If fC is set...
+   or    c               ;; [1] ... set the low bit into high nibble
+loop1:
+
+   ;; Loop for second and third pixels
 px1_repeat:
-   ld   de, #pen2mode1px ;; [3] DE points to the start of the colour table
-   ld    a, (hl)         ;; [2] A = Firmware colour for next pixel (to be added to DE, 
-                         ;; .... as it is the index of the colour value to retrieve)
-   add_de_a              ;; [5] DE += A (A contains next color translation to Pixel 0 bitpattern)
-   
-   ld    a, (de)         ;; [2] A = Screen format for Firmware colour for Pixel
-   or    c               ;; [1] Mix (OR) pixel format with accumulated previous pixel format conversions
-   rlca                  ;; [1] Rotate A left, to left space for next pixel at the same 2 bits (7 and 3)
-   ld    c, a            ;; [1] C = Acumulated screen pixels format
+   add   a               ;; [1] Make space to the next pixel,
+   add   a               ;; [1] ... shifting two bits to the left
    inc  hl               ;; [2] HL points to next pixel in firmware colour (next parameter)
-   djnz px1_repeat       ;; [3/4] Repeat until B=0 (until 4 pixels have been converted)
+   or  (hl)              ;; [2] Read the pixel
 
-   ld    l, c            ;; [1] L = B, put return value into L
+   rra                   ;; [1] Shift to the right, the bit 0 (low bit of pixel) is stored into fC
+   jr   nc, loop2        ;; [2/3] If fC is set...
+   or    c               ;; [1] ... set the low bit into high nibble
+loop2:
+   djnz px1_repeat       ;; [3/4] Repeat until B=0 (until 2 pixels have been converted)
+
+   ;; Process the last pixel
+   add   a               ;; [1] Shift to the left, to left space for last pixel
+   inc  hl               ;; [2] HL points to next pixel in firmware colour (next parameter)
+   ld    b, (hl)         ;; [2] A = Firmware colour for next pixel
+   srl   b               ;; [2] Shift to the right, the bit 0 (low bit of pixel) is stored into fC
+   jr   nc, loop3        ;; [2/3] If fC is set...
+   or    c               ;; [1] ... set the low bit into high nibble
+loop3:
+   or    b               ;; [1] Set the high bit into high nibble
+
+   ld    l, a            ;; [1] L = A, put return value into L
 
    ret                   ;; [3] return
 
-;;
-;;    Mode 1 Color conversion table (PEN to Screen pixel format)
-;;
-;;    This table converts PEN values (palette indexes from 0 to 4) into screen pixel format values in mode 1. 
-;; In mode 1, each byte has 4 pixels (P0, P1, P2, P3). This table converts to Pixel 0 (P0) format. Getting values for
-;; other pixels require shifting this byte to the right 1 to 3 times (depending on which pixel is required).
-;;
-pen2mode1px: .db 0x00, 0x08, 0x80, 0x88


### PR DESCRIPTION
Version of this function, based on the following algorithm:
* the accumulator stores the rotated bits
* one more rotation is made to test the lowest bit, and if positive, a bit is activated in the high nibble

Removed references to byte table "pen2mode1px" as it is not needed in the function or anywhere else (that has been detected).

Comments have been modified to remove unnecessary parts, update size in bytes, microseconds, cycles. The scheme that explains the arrangement of the bits of the pixels packed in the bytes of the video memory has also been modified.