### PR TITLE
Fix/sdcc fedora 42 compilation

### DIFF
--- a/cpctelera/tools/dskgen/src/Dsk.cc
+++ b/cpctelera/tools/dskgen/src/Dsk.cc
@@ -143,8 +143,9 @@ int Dsk::AddFile(FileToProcess &file) {
                 u8* newData = new u8[newLength];
                 
                 memcpy(newData + headerSize, fileData, file.Length);
-                u8* oldData = fileData;
-                delete oldData;
+                delete [] fileData; // fix: delete should use [], as it is an array
+                //u8* oldData = fileData;
+                //delete oldData;
 
                 fillAmsdosHeader((struct AmsdosHeader*)newData, file);
                 file.Length += headerSize;

--- a/cpctelera/tools/dskgen/src/jsoncpp.cpp
+++ b/cpctelera/tools/dskgen/src/jsoncpp.cpp
@@ -72,8 +72,8 @@ license you like.
 
 
 
-
-#include "json/json.h"
+// Fix: It was previously including system header, due to bad relative route
+#include "../include/json/json.h"
 
 #ifndef JSON_IS_AMALGAMATION
 #error "Compile with -I PATH_TO_JSON_DIRECTORY"
@@ -379,7 +379,7 @@ bool Reader::readValue() {
     break;
   case tokenNull:
     {
-    Value v;
+    Value v{};
     currentValue().swapPayload(v);
     currentValue().setOffsetStart(token.start_ - begin_);
     currentValue().setOffsetLimit(token.end_ - begin_);
@@ -392,7 +392,7 @@ bool Reader::readValue() {
       // "Un-read" the current token and mark the current value as a null
       // token.
       current_--;
-      Value v;
+      Value v{};
       currentValue().swapPayload(v);
       currentValue().setOffsetStart(current_ - begin_ - 1);
       currentValue().setOffsetLimit(current_ - begin_);
@@ -1315,7 +1315,7 @@ bool OurReader::readValue() {
     break;
   case tokenNull:
     {
-    Value v;
+    Value v{};
     currentValue().swapPayload(v);
     currentValue().setOffsetStart(token.start_ - begin_);
     currentValue().setOffsetLimit(token.end_ - begin_);
@@ -1328,7 +1328,7 @@ bool OurReader::readValue() {
       // "Un-read" the current token and mark the current value as a null
       // token.
       current_--;
-      Value v;
+      Value v{};
       currentValue().swapPayload(v);
       currentValue().setOffsetStart(current_ - begin_ - 1);
       currentValue().setOffsetLimit(current_ - begin_);
@@ -2655,7 +2655,10 @@ Value::Value(ValueType vtype) {
   initBasic(vtype);
   switch (vtype) {
   case nullValue:
-    break;
+    // Fix: Removing this break causes int initialization for nullValues.
+    //      As type is null, the value doesn't matters. However, having no value initialized
+    //      launches compiler warnings on "use without initialization", which is fair.
+    //break;
   case intValue:
   case uintValue:
     value_.int_ = 0;

--- a/cpctelera/tools/iDSK-0.13/Makefile
+++ b/cpctelera/tools/iDSK-0.13/Makefile
@@ -5,7 +5,7 @@ COMP    = g++
 TARGET  = $(BINDIR)/iDSK
 SRCFILES= $(wildcard $(SRCDIR)/*.cpp)
 OBJFILES= $(foreach F, $(SRCFILES), $(patsubst $(SRCDIR)%,$(OBJDIR)%,$(F:%.cpp=%.o)))
-CPFLAGS = -O3 -Wall -pedantic -fsigned-char
+CPFLAGS = -std=c++98 -O3 -Wall -pedantic -fsigned-char
 LDLIBS  = 
 
 .PHONY: clean cleanall

--- a/cpctelera/tools/sdcc-3.6.8-r9946/src/sdas/linksrc/aslink.h
+++ b/cpctelera/tools/sdcc-3.6.8-r9946/src/sdas/linksrc/aslink.h
@@ -1308,7 +1308,7 @@ extern  VOID            s19(int i);
 extern  VOID            sflush(void);
 
 /* EEP: lkelf.c */
-extern  VOID            elf();
+extern  VOID            elf(int i);
 
 /* JCF: lkmem.c */
 extern int summary(struct area * xp);


### PR DESCRIPTION
In Fedora 42, the building of the tools(SDCC) crashes because a mismatch of the signature of elf() function. With this small change, I am able to build cpctelera properly.

Tested in Debian 12.10 and Fedora 42.