### PR TITLE
Winape and gitignore fixes

### DIFF
--- a/cpctelera/tools/scripts/.gitignore
+++ b/cpctelera/tools/scripts/.gitignore
@@ -3,4 +3,5 @@
 cpct_bin2sna
 cpct_tmx2data
 cpct_binpatch
+cpct_png2chars
 *.exe

--- a/cpctelera/tools/scripts/cpct_winape
+++ b/cpctelera/tools/scripts/cpct_winape
@@ -65,7 +65,7 @@
 
 # Script configuration
 CPCT_SCRIPTS_FOLDER=$(dirname $0)
-CPCT_TOOLS_FOLDER=${CPCT_SCRIPTS_FOLDER}/..
+CPCT_TOOLS_FOLDER=$(realpath ${CPCT_SCRIPTS_FOLDER}/..)
 WWW_WINAPE=http://winape.net/download/WinAPE20B2.zip
 WINAPE_EXE=WinApe.exe
 WINAPE_INI=WinAPE.ini


### PR DESCRIPTION
- make git ignore the cpct_png2chars binary created on build
- fix winape script tools directory