### PR TITLE
cpctelera/tools/sdcc-3.6.8-r9946/src/support/sdbinutils/libiberty/cpl…

### DIFF
--- a/cpctelera/tools/sdcc-3.6.8-r9946/src/support/sdbinutils/libiberty/cplus-dem.c
+++ b/cpctelera/tools/sdcc-3.6.8-r9946/src/support/sdbinutils/libiberty/cplus-dem.c
@@ -493,7 +493,7 @@ recursively_demangle (struct work_stuff *, const char **, string *, int);
 static int
 consume_count (const char **type)
 {
-  int count = 0;
+  volatile int count = 0;
 
   if (! ISDIGIT ((unsigned char)**type))
     return -1;


### PR DESCRIPTION
## Summary

Our tool detected a potential overflow vulnerability in `cpctelera/tools/sdcc-3.6.8-r9946/src/support/sdbinutils/libiberty/cplus-dem.c` which was cloned from [rizinorg/rz-libdemangle](https://github.com/rizinorg/rz-libdemangle) but did not receive the security patch. The original issue was reported and fixed under [CVE-2023-40022](https://nvd.nist.gov/vuln/detail/CVE-2023-40022).

## Proposed Fix

Apply the same patch as the one in lua/lua to eliminate the vulnerability.

## Reference

https://nvd.nist.gov/vuln/detail/CVE-2023-40022
https://github.com/rizinorg/rz-libdemangle/commit/51d016750e704b27ab8ace23c0f72acabca67018